### PR TITLE
Fix weather.ttf load failure

### DIFF
--- a/styl/index.styl
+++ b/styl/index.styl
@@ -1,6 +1,6 @@
 @font-face {
   font-family: 'Weather';
-  src: url('fonts/weather.ttf') format('truetype');
+  src: url('../fonts/weather.ttf') format('truetype');
 }
 
 .weather {


### PR DESCRIPTION
Weather font gets copied to `build/fonts/weather.ttf` whereas css goes into `build/css/mozaik.css`. Thus the change in URL.
