### PR TITLE
Allow weather code to be missing and only warn about it

### DIFF
--- a/src/components/WeatherCodeHelper.js
+++ b/src/components/WeatherCodeHelper.js
@@ -31,7 +31,8 @@ var codes = {
 module.exports = {
     icon(code) {
         if (!codes[code]) {
-            throw new Error('No icon defined for code "' + code + '"');
+            console.warn('No icon defined for code "' + code + '"');
+            return 'no-code';
         }
 
         return codes[code];


### PR DESCRIPTION
There are many weather codes missing causing an error and **execution termination**. Instead, just log the missing codes in warn level.

On related note, not sure what icon set is being used, but this one seems quite comprehensive: http://erikflowers.github.io/weather-icons/
