### PR TITLE
Handle failure when this.state.current.weather is undefined

### DIFF
--- a/src/components/Weather.jsx
+++ b/src/components/Weather.jsx
@@ -78,7 +78,7 @@ var Weather = React.createClass({
         var tempNode        = null;
         var iconNode        = null;
 
-        if (this.state.current) {
+        if (this.state.current && this.state.current.weather) {
             if (this.state.current.weather.length > 0) {
                 //{this.state.current.weather[0].id}
                 descriptionNode = (


### PR DESCRIPTION
Handling the case (which seem to happen every now and then) where
the weather value is not defined.
